### PR TITLE
Fix "Frmework" typo in info.json

### DIFF
--- a/keyboards/framework_rp2040_controller/info.json
+++ b/keyboards/framework_rp2040_controller/info.json
@@ -1,6 +1,6 @@
 {
     "manufacturer": "Arya",
-    "keyboard_name": "Frmework Input Cover RP2040 Controller",
+    "keyboard_name": "Framework Input Cover RP2040 Controller",
     "maintainer": "CRImier",
     "bootloader": "rp2040",
     "diode_direction": "COL2ROW",


### PR DESCRIPTION
Fixed simple typo in the `info.json` file. I assume this meant to say "Framework" and not "Frmework", although it could be a stylistic choice, idk. My .002 cents

Nice project, thank you for making it available.